### PR TITLE
Run the game engine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,8 @@ def jettyVersion = '9.3.8.v20160314'
 def jerseyVersion = '2.22.2'
 
 dependencies {
-    compile 'org.terasology.engine:engine:1.0.0'
+    //compile 'org.terasology.engine:engine:1.0.0'
+    compile project(':engine')
 
     compile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: jettyVersion
     compile group: 'org.eclipse.jetty.websocket', name: 'websocket-server', version: jettyVersion

--- a/build.gradle
+++ b/build.gradle
@@ -99,3 +99,4 @@ run.dependsOn rootProject.moduleClasses
 run.dependsOn setupServerConfig
 run.dependsOn setupServerModules
 run.workingDir = rootDir
+run.args = ["-homedir=terasology-server"]

--- a/build.gradle
+++ b/build.gradle
@@ -2,24 +2,18 @@ plugins {
     id "org.standardout.versioneye" version "1.3.0"
 }
 
-apply plugin: 'java'
+apply from: "$rootDir/config/gradle/artifactory.gradle"
 apply plugin: 'application'
-apply plugin: 'eclipse'
-apply plugin: 'idea'
 
 apply from: 'config/gradle/versioning.gradle'
 
+import groovy.json.JsonBuilder
+
 mainClassName = "org.terasology.web.ServerMain"
-group = 'org.terasology.web'
 
-// Same repository configuration as root project
-repositories {
-   mavenCentral()
-
-    // MovingBlocks Artifactory instance for libs not readily available elsewhere plus our own libs
-    maven {
-        url "http://artifactory.terasology.org/artifactory/virtual-repo-live"
-    }
+ext {
+    localServerDataPath = 'terasology-server'
+    group = 'org.terasology.web'
 }
 
 task wrapper(type: Wrapper) {
@@ -44,3 +38,64 @@ dependencies {
     testCompile 'junit:junit:4.12'
 }
 
+// Copied from PC facade
+// By delaying this task to doLast (the << bit) we don't get the headless server dir set up unless actually wanting it
+// TODO: This is not the Gradle Way. Needs more declared output-fu to determine up-to-date instead of the if
+task setupServerConfig() << {
+    description "Parses parameters passed via Gradle and writes them to the local run-from-source server dir's config.cfg"
+
+    def json = new JsonBuilder()
+
+    def serverRoot = rootProject.file(localServerDataPath);
+    def config = new File(serverRoot, 'config.cfg')
+
+    if (!config.exists()) {
+
+        serverRoot.mkdir()
+        logger.lifecycle("Creating config file $config")
+
+        json {
+            worldGeneration {
+                if (project.hasProperty('seed')) {
+                    logger.lifecycle("  Seed value: $seed");
+                    defaultSeed seed
+                }
+                if (project.hasProperty('worldGen')) {
+                    logger.lifecycle("  World Generator: $worldGen");
+                    defaultGenerator worldGen
+                }
+            }
+            defaultModSelection {
+                if (project.hasProperty('extraModules')) {
+                    logger.lifecycle("  Enabling modules: $extraModules");
+                    modules extraModules.tokenize(" ,")
+                }
+            }
+        }
+        config.text = json.toPrettyString()
+    }
+}
+
+// TODO: Seems to always be up to date so no modules get copied
+task setupServerModules(type: Sync) << {
+    description 'Parses "extraModules" - a comma-separated list of modules and puts them into ' + localServerDataPath
+
+    if (project.hasProperty('extraModules')) {
+        // Grab modules from Artifactory - cheats by declaring them as dependencies
+        extraModules.tokenize(' ,').each { String module ->
+            println "Extra module: " + module
+            dependencies {
+                modules group: 'org.terasology.modules', name: module, version: '+', changing: 'true'
+            }
+        }
+    }
+
+    from(configurations.modules)
+    into(new File(rootProject.file(localServerDataPath), "modules"))
+}
+
+run.dependsOn rootProject.extractNatives
+run.dependsOn rootProject.moduleClasses
+run.dependsOn setupServerConfig
+run.dependsOn setupServerModules
+run.workingDir = rootDir

--- a/src/main/java/org/terasology/web/EngineRunner.java
+++ b/src/main/java/org/terasology/web/EngineRunner.java
@@ -15,8 +15,6 @@
  */
 package org.terasology.web;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.engine.TerasologyEngine;
 import org.terasology.engine.TerasologyEngineBuilder;
 import org.terasology.engine.subsystem.common.hibernation.HibernationSubsystem;
@@ -28,8 +26,6 @@ import org.terasology.engine.subsystem.headless.mode.HeadlessStateChangeListener
 import org.terasology.engine.subsystem.headless.mode.StateHeadlessSetup;
 
 final class EngineRunner {
-
-    private static final Logger logger = LoggerFactory.getLogger(ServerMain.class);
 
     private EngineRunner() {
     }

--- a/src/main/java/org/terasology/web/EngineRunner.java
+++ b/src/main/java/org/terasology/web/EngineRunner.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.web;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.engine.LoggingContext;
+import org.terasology.engine.TerasologyEngine;
+import org.terasology.engine.TerasologyEngineBuilder;
+import org.terasology.engine.paths.PathManager;
+import org.terasology.engine.subsystem.common.hibernation.HibernationSubsystem;
+import org.terasology.engine.subsystem.headless.HeadlessAudio;
+import org.terasology.engine.subsystem.headless.HeadlessGraphics;
+import org.terasology.engine.subsystem.headless.HeadlessInput;
+import org.terasology.engine.subsystem.headless.HeadlessTimer;
+import org.terasology.engine.subsystem.headless.mode.HeadlessStateChangeListener;
+import org.terasology.engine.subsystem.headless.mode.StateHeadlessSetup;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+final class EngineRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(ServerMain.class);
+
+    private EngineRunner() {
+    }
+
+    static void runEngine() {
+        try {
+            PathManager.getInstance().useOverrideHomePath(Paths.get("terasology-server"));
+        } catch (IOException e) {
+            logger.error("Failed to access engine data directory", e);
+        }
+        setupLogging();
+        TerasologyEngineBuilder builder = new TerasologyEngineBuilder();
+        populateSubsystems(builder);
+        TerasologyEngine engine = builder.build();
+        engine.subscribeToStateChange(new HeadlessStateChangeListener(engine));
+        engine.run(new StateHeadlessSetup());
+    }
+
+    private static void populateSubsystems(TerasologyEngineBuilder builder) {
+        builder.add(new HeadlessGraphics())
+                .add(new HeadlessTimer())
+                .add(new HeadlessAudio())
+                .add(new HeadlessInput())
+                .add(new HibernationSubsystem());
+    }
+
+    private static void setupLogging() {
+        Path path = PathManager.getInstance().getLogPath();
+        if (path == null) {
+            path = Paths.get("logs");
+        }
+
+        LoggingContext.initialize(path);
+    }
+}

--- a/src/main/java/org/terasology/web/EngineRunner.java
+++ b/src/main/java/org/terasology/web/EngineRunner.java
@@ -17,10 +17,8 @@ package org.terasology.web;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.engine.LoggingContext;
 import org.terasology.engine.TerasologyEngine;
 import org.terasology.engine.TerasologyEngineBuilder;
-import org.terasology.engine.paths.PathManager;
 import org.terasology.engine.subsystem.common.hibernation.HibernationSubsystem;
 import org.terasology.engine.subsystem.headless.HeadlessAudio;
 import org.terasology.engine.subsystem.headless.HeadlessGraphics;
@@ -28,10 +26,6 @@ import org.terasology.engine.subsystem.headless.HeadlessInput;
 import org.terasology.engine.subsystem.headless.HeadlessTimer;
 import org.terasology.engine.subsystem.headless.mode.HeadlessStateChangeListener;
 import org.terasology.engine.subsystem.headless.mode.StateHeadlessSetup;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 
 final class EngineRunner {
 
@@ -41,12 +35,6 @@ final class EngineRunner {
     }
 
     static void runEngine() {
-        try {
-            PathManager.getInstance().useOverrideHomePath(Paths.get("terasology-server"));
-        } catch (IOException e) {
-            logger.error("Failed to access engine data directory", e);
-        }
-        setupLogging();
         TerasologyEngineBuilder builder = new TerasologyEngineBuilder();
         populateSubsystems(builder);
         TerasologyEngine engine = builder.build();
@@ -62,12 +50,4 @@ final class EngineRunner {
                 .add(new HibernationSubsystem());
     }
 
-    private static void setupLogging() {
-        Path path = PathManager.getInstance().getLogPath();
-        if (path == null) {
-            path = Paths.get("logs");
-        }
-
-        LoggingContext.initialize(path);
-    }
 }

--- a/src/main/java/org/terasology/web/ServerMain.java
+++ b/src/main/java/org/terasology/web/ServerMain.java
@@ -18,15 +18,12 @@ package org.terasology.web;
 
 import java.util.Locale;
 
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
-import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.server.mvc.freemarker.FreemarkerMvcFeature;
 import org.glassfish.jersey.servlet.ServletContainer;
@@ -72,6 +69,8 @@ public final class ServerMain {
 
         server.start();
         logger.info("Server started on port {}!", port);
+
+        EngineRunner.runEngine();
 
         server.join();
     }

--- a/src/main/java/org/terasology/web/ServerMain.java
+++ b/src/main/java/org/terasology/web/ServerMain.java
@@ -133,7 +133,7 @@ public final class ServerMain {
 
         ResourceHandler logFileResourceHandler = new ResourceHandler();
         logFileResourceHandler.setDirectoriesListed(true);
-        logFileResourceHandler.setResourceBase("logs");
+        logFileResourceHandler.setResourceBase(LoggingContext.getLoggingPath().toString());
 
         ContextHandler logContext = new ContextHandler("/logs"); // the server uri path
         logContext.setHandler(logFileResourceHandler);

--- a/src/main/java/org/terasology/web/ServerMain.java
+++ b/src/main/java/org/terasology/web/ServerMain.java
@@ -19,6 +19,8 @@ package org.terasology.web;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 
 import org.eclipse.jetty.server.Server;
@@ -47,6 +49,7 @@ public final class ServerMain {
 
     private static final Logger logger = LoggerFactory.getLogger(ServerMain.class);
 
+    private static final String[] ARGS_HELP = {"--help", "-help", "/help", "-h", "/h", "-?", "/?"};
     private static final String ARG_ENGINE_DIR = "-homedir=";
     private static final String ARG_ENGINE_SERVER_PORT = "-serverPort=";
 
@@ -84,14 +87,19 @@ public final class ServerMain {
     }
 
     private static void handleArgs(String[] args) {
+        List<String> helpArgs = Arrays.asList(ARGS_HELP);
         Path homePath = Paths.get(""); //use current directory as default
         for (String arg: args) {
-            if (arg.startsWith(ARG_ENGINE_DIR)) {
+            if (helpArgs.contains(arg)) {
+                printUsage();
+                System.exit(0);
+            } else if (arg.startsWith(ARG_ENGINE_DIR)) {
                 homePath = Paths.get(arg.substring(ARG_ENGINE_DIR.length()));
             } else if (arg.startsWith(ARG_ENGINE_SERVER_PORT)) {
                 System.setProperty(ConfigurationSubsystem.SERVER_PORT_PROPERTY, arg.substring(ARG_ENGINE_SERVER_PORT.length()));
             } else {
                 System.err.println("Unrecognized command line argument \"" + arg + "\"");
+                printUsage();
                 System.exit(1);
             }
         }
@@ -101,6 +109,14 @@ public final class ServerMain {
             System.err.println("Failed to access the engine data directory: " + e.getMessage());
             System.exit(1);
         }
+    }
+
+    private static void printUsage() {
+        System.out.println("Available command line options:");
+        System.out.println(ARG_ENGINE_DIR + ": use the specified directory as the Terasology engine data directory");
+        System.out.println(ARG_ENGINE_SERVER_PORT + ": use the specified port for the Terasology server");
+        System.out.println();
+        System.out.println("The web server port (default 8080) can be overridden by setting the environment variable PORT.");
     }
 
     private static void setupLogging() {

--- a/src/main/java/org/terasology/web/ServerMain.java
+++ b/src/main/java/org/terasology/web/ServerMain.java
@@ -54,14 +54,10 @@ public final class ServerMain {
         // no instances
     }
 
-    /**
-     * @param args ignored
-     * @throws Exception
-     */
     public static void main(String[] args) throws Exception {
 
-        setupLogging();
         handleArgs(args);
+        setupLogging();
 
         String portEnv = System.getenv("PORT");
         if (portEnv == null) {
@@ -75,7 +71,7 @@ public final class ServerMain {
         // define the date format.
         Locale.setDefault(Locale.ENGLISH);
 
-        Server server = createServer(port.intValue(),
+        Server server = createServer(port,
                 new LogServlet(),
                 new AboutServlet());
 
@@ -95,14 +91,14 @@ public final class ServerMain {
             } else if (arg.startsWith(ARG_ENGINE_SERVER_PORT)) {
                 System.setProperty(ConfigurationSubsystem.SERVER_PORT_PROPERTY, arg.substring(ARG_ENGINE_SERVER_PORT.length()));
             } else {
-                logger.error("Unrecognized command line argument \"" + arg + "\"");
+                System.err.println("Unrecognized command line argument \"" + arg + "\"");
                 System.exit(1);
             }
         }
         try {
             PathManager.getInstance().useOverrideHomePath(homePath);
         } catch (IOException e) {
-            logger.error("Failed to access the engine data directory", e);
+            System.err.println("Failed to access the engine data directory: " + e.getMessage());
             System.exit(1);
         }
     }

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -21,6 +21,6 @@
         <appender-ref ref="FILE"/>
     </root>
 
-    <logger name="org.terasology" level="DEBUG" />
+    <logger name="org.terasology" level="INFO" />
 
 </configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,26 +1,51 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
+﻿<configuration>
 
-    <timestamp key="timestamp" datePattern="yyyy-MM-dd'T'HH_mm_ss"/>
+    <!-- Report all changes to this configuration on System.out -->
+    <!--statusListener class="ch.qos.logback.core.status.OnConsoleStatusListener" /-->
+
+    <!-- Propagate all log level changes to java.util.logging -->
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
+    <appender name="SIFT" class="ch.qos.logback.classic.sift.SiftingAppender">
+        <!-- in the absence of the class attribute, it is assumed that the
+             desired discriminator type is MDCBasedDiscriminator -->
+        <discriminator>
+            <key>phase</key>
+            <defaultValue>init</defaultValue>
+        </discriminator>
+        <timeout>30 seconds</timeout>
+        <sift>
+            <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+                <file>${logFileFolder}/Terasology-${phase}.log</file>
+                <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+                    <!-- daily rollover -->
+                    <fileNamePattern>${logFileFolder}/Terasology-${phase}-%d{yyyy-MM-dd}.log</fileNamePattern>
+
+                    <!-- keep 3 days' worth of history -->
+                    <maxHistory>3</maxHistory>
+                </rollingPolicy>
+                <encoder>
+                    <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+                </encoder>
+            </appender>
+        </sift>
+    </appender>
 
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type PatternLayoutEncoder by default -->
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
-    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>logs/report-${timestamp}.log</file>
-        <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
-        </encoder>
-    </appender>
-
-    <root level="INFO">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="FILE"/>
+    <root level="${logOverrideLevel:-debug}">
+        <appender-ref ref="SIFT" />
+        <appender-ref ref="CONSOLE" />
     </root>
 
-    <logger name="org.terasology" level="INFO" />
+    <logger name="org.terasology" level="${logOverrideLevel:-info}" />
+    <logger name="org.reflections.Reflections" level="${logOverrideLevel:-error}" />
 
 </configuration>


### PR DESCRIPTION
For this first pull request I added the code to make this an actual engine facade. The engine runs on the main thread, while the Jetty web server runs on separate threads. Lots of "inspiration" and parts of code come from the standard PC facade. Here is how I set up my workspace, hoping it's the correct way (it should be according to the [wiki instructions](https://github.com/MovingBlocks/Terasology/wiki/Codebase-Structure#facades) for facades): 
- from my local clone of the [engine repository](https://github.com/MovingBlocks/Terasology), ran `gradlew fetchFacadeServer`
- linked my fork with the nested git repository

Put shortly, to test this branch you can follow this process:
- From the root of your local clone of [MovingBlocks/Terasology](https://github.com/MovingBlocks/Terasology), run `gradlew fetchFacadeServer`. On a freshly cloned copy I usually have no issues if I do a `gradlew build` before, while if I recall correctly I had the engine complaining about missing world generators when running without manually building the engine first. Maybe I didn't set up all the dependencies properly (*).
- then, move to the nested facade repository with `cd facades/Server` and reach this branch using the following commands:
```
git remote add fork "https://github.com/gianluca-nitti/FacadeServer"
git pull fork
git checkout engine-runner
```
- now you can go back to the root repository (`cd ../..`) and run this facade with `gradlew facades:Server:run`.

(*) about the Gradle configuration: I made some tweaks to the `build.gradle` according to the other facades, to setup a basic server configuration; it all works but I'm not sure if it's the correct way and how to correctly handle packaging/distribution.
Also, I added two command line arguments, one to set the engine data directory and the other for the game server port. I'm not sure if the web server port too should be settable via a command line switch, for the moment I didn't change the existing code which sets it according to the PORT environment variable.

Maybe we can also improve these logistics details later if necessary, I focused on setting up a working development environment since I'm a bit late on the timeline.

Running the project as a facade introduced some issues with paths, because when you run via `gradlew facades:Server:run` the working directory of the program is the root repository and not the root of the facade, so at the moment you get 404s if you try to access `localhost:8080/`; I fixed the path for the logs using the engine's `LoggingContext`, so they are correctly served at `localhost:8080/logs`. In my opinion we could put the static web files in an appropriate subdirectory of `src/main/resources/` but I think this will be relevant when I'll work on the frontend; my main goal at the moment is setting up the authentication API.