### PR TITLE
Modules install resource

### DIFF
--- a/src/main/java/org/terasology/web/resources/ResourceManager.java
+++ b/src/main/java/org/terasology/web/resources/ResourceManager.java
@@ -25,6 +25,7 @@ import org.terasology.registry.InjectionHelper;
 import org.terasology.web.io.ActionResult;
 import org.terasology.web.resources.games.GamesResource;
 import org.terasology.web.resources.modules.AvailableModulesResource;
+import org.terasology.web.resources.modules.ModuleInstallerResource;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -52,6 +53,7 @@ public final class ResourceManager {
         registerAndPutResource(context, new EngineStateResource());
         registerAndPutResource(context, new GamesResource());
         registerAndPutResource(context, new AvailableModulesResource());
+        registerAndPutResource(context, new ModuleInstallerResource());
         if (gameState instanceof StateIngame) {
             registerAndPutResource(context, new ConsoleResource());
             registerAndPutResource(context, new OnlinePlayersResource());

--- a/src/main/java/org/terasology/web/resources/modules/AvailableModulesResource.java
+++ b/src/main/java/org/terasology/web/resources/modules/AvailableModulesResource.java
@@ -15,29 +15,21 @@
  */
 package org.terasology.web.resources.modules;
 
-import org.terasology.engine.module.DependencyResolutionFailedException;
 import org.terasology.engine.module.ModuleManager;
 import org.terasology.i18n.I18nMap;
 import org.terasology.module.Module;
 import org.terasology.module.ModuleMetadata;
-import org.terasology.naming.Name;
 import org.terasology.network.Client;
 import org.terasology.registry.In;
-import org.terasology.utilities.download.MultiFileTransferProgressListener;
-import org.terasology.web.ServerAdminsManager;
-import org.terasology.web.io.ActionResult;
 import org.terasology.web.resources.ReadableResource;
 import org.terasology.web.resources.ResourceAccessException;
-import org.terasology.web.resources.WritableResource;
 import org.terasology.world.generator.internal.WorldGeneratorManager;
 
 import java.util.Comparator;
-import java.util.Set;
-import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class AvailableModulesResource implements ReadableResource<AvailableModulesData>, WritableResource<Name[]> {
+public class AvailableModulesResource implements ReadableResource<AvailableModulesData> {
 
     @In
     private ModuleManager moduleManager;
@@ -55,38 +47,5 @@ public class AvailableModulesResource implements ReadableResource<AvailableModul
         Stream<ModuleMetadata> modules = moduleManager.getRegistry().stream().map(Module::getMetadata)
                 .sorted(Comparator.comparing(ModuleMetadata::getDisplayName, Comparator.comparing(I18nMap::value)));
         return new AvailableModulesData(modules.collect(Collectors.toList()), worldGeneratorManager.getWorldGenerators());
-    }
-
-    @Override
-    public Class<Name[]> getDataType() {
-        return Name[].class;
-    }
-
-    @Override
-    public void write(Client requestingClient, Name[] data) throws ResourceAccessException {
-        ServerAdminsManager.checkClientIsServerAdmin(requestingClient.getId());
-        executeCallable(moduleManager.getInstallManager().updateRemoteRegistry());
-        Set<Module> allModules;
-        try {
-            allModules = moduleManager.getInstallManager().getAllModulesToDownloadFor(data);
-        } catch (DependencyResolutionFailedException ex) {
-            throw new ResourceAccessException(new ActionResult(ActionResult.Status.GENERIC_ERROR, ex.getMessage()));
-        }
-        executeCallable(moduleManager.getInstallManager().createInstaller(allModules, new MultiFileTransferProgressListener() {
-            @Override
-            public void onSizeMetadataProgress(int index, int totalUrls) {
-            }
-            @Override
-            public void onDownloadProgress(long totalTransferredBytes, long totalBytes, int completedFiles, int nFiles) {
-            }
-        }));
-    }
-
-    private void executeCallable(Callable process) throws ResourceAccessException {
-        try {
-            process.call();
-        } catch (Exception ex) {
-            throw new ResourceAccessException(new ActionResult(ActionResult.Status.GENERIC_ERROR, ex.getMessage()));
-        }
     }
 }

--- a/src/main/java/org/terasology/web/resources/modules/ModuleInstallerResource.java
+++ b/src/main/java/org/terasology/web/resources/modules/ModuleInstallerResource.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.web.resources.modules;
+
+import org.terasology.engine.module.DependencyResolutionFailedException;
+import org.terasology.engine.module.ModuleManager;
+import org.terasology.module.Module;
+import org.terasology.naming.Name;
+import org.terasology.network.Client;
+import org.terasology.registry.In;
+import org.terasology.utilities.download.MultiFileTransferProgressListener;
+import org.terasology.web.ServerAdminsManager;
+import org.terasology.web.io.ActionResult;
+import org.terasology.web.resources.ObservableReadableResource;
+import org.terasology.web.resources.ResourceAccessException;
+import org.terasology.web.resources.WritableResource;
+
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class ModuleInstallerResource extends ObservableReadableResource<String> implements WritableResource<Name[]> {
+
+    @In
+    private ModuleManager moduleManager;
+
+    private ExecutorService installExecutor = Executors.newSingleThreadExecutor();
+    private String status = "Idle";
+
+    @Override
+    public String getName() {
+        return "moduleInstaller";
+    }
+
+    @Override
+    public Class<Name[]> getDataType() {
+        return Name[].class;
+    }
+
+    @Override
+    public String read(Client requestingClient) throws ResourceAccessException {
+        return status;
+    }
+
+    @Override
+    public void write(Client requestingClient, Name[] data) throws ResourceAccessException {
+        ServerAdminsManager.checkClientIsServerAdmin(requestingClient.getId());
+        executeCallable(moduleManager.getInstallManager().updateRemoteRegistry());
+        Set<Module> allModules;
+        try {
+            allModules = moduleManager.getInstallManager().getAllModulesToDownloadFor(data);
+        } catch (DependencyResolutionFailedException ex) {
+            throw new ResourceAccessException(new ActionResult(ActionResult.Status.GENERIC_ERROR, ex.getMessage()));
+        }
+        installExecutor.submit(() -> setStatus("Initializing installation"));
+        installExecutor.submit(moduleManager.getInstallManager().createInstaller(allModules, new MultiFileTransferProgressListener() {
+            @Override
+            public void onSizeMetadataProgress(int index, int totalUrls) {
+                setStatus(String.format("Retrieving file size information - %d of %d", index, totalUrls));
+            }
+            @Override
+            public void onDownloadProgress(long totalTransferredBytes, long totalBytes, int completedFiles, int nFiles) {
+                int globalPercentage = (int) (totalTransferredBytes * 100f / totalBytes);
+                setStatus(String.format("Downloaded modules: %d of %d\nDownloaded bytes: %d of %d\nGlobal progress: %d%%",
+                        completedFiles, nFiles, totalTransferredBytes, totalBytes, globalPercentage));
+            }
+        }));
+        // the executor is single-threaded and tasks run sequentially, so the following one sets the status back to "Idle" after the install finishes
+        installExecutor.submit(() -> setStatus("Idle"));
+    }
+
+    private void setStatus(String value) {
+        status = value;
+        notifyChangedAll();
+    }
+
+    private void executeCallable(Callable process) throws ResourceAccessException {
+        try {
+            process.call();
+        } catch (Exception ex) {
+            throw new ResourceAccessException(new ActionResult(ActionResult.Status.GENERIC_ERROR, ex.getMessage()));
+        }
+    }
+}

--- a/src/main/java/org/terasology/web/webSocket/ErrorReportingWriteCallback.java
+++ b/src/main/java/org/terasology/web/webSocket/ErrorReportingWriteCallback.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.web.webSocket;
+
+import org.eclipse.jetty.websocket.api.WriteCallback;
+import org.slf4j.Logger;
+
+public class ErrorReportingWriteCallback implements WriteCallback {
+
+    private final Logger targetLogger;
+
+    public ErrorReportingWriteCallback(Logger targetLogger) {
+        this.targetLogger = targetLogger;
+    }
+
+    @Override
+    public void writeFailed(Throwable x) {
+        targetLogger.warn("Unable to send WebSocket message to client", x);
+    }
+
+    @Override
+    public void writeSuccess() {
+        // do nothing
+    }
+}


### PR DESCRIPTION
This small pull request adds the feature which allows server administrators to install modules in the server using the web interface or API.

The added resource, `ModuleInstallerResource`:
- implements `WritableResource<Name[]>` in the sense that you can write to it (i.e. with a POST HTTP request or with the appropriate WebSocket message) a list of modules you want to install (which does not need to include all the dependencies; the dependency resolution happens server-side and the server adds the required dependencies - if any - to the download list automatically)
- extends `ObservableReadableResource<String>` in the sense that you can read from it the current status of the installation, and every connected WebSocket client is automatically notified when the status changes (i.e. a progress in the download is made, or the installation has been completed).

**Important**: for this to work, the engine must be built including my commits on pull request MovingBlocks/Terasology#3028; FacadeServer won't compile if classes introduced in that PR, like `ModuleInstallManager`, are missing.