### PR TITLE
Add resources to obtain or modify server's MOTD and port

### DIFF
--- a/src/main/java/org/terasology/web/resources/ResourceManager.java
+++ b/src/main/java/org/terasology/web/resources/ResourceManager.java
@@ -23,6 +23,8 @@ import org.terasology.engine.modes.StateIngame;
 import org.terasology.entitySystem.systems.ComponentSystem;
 import org.terasology.registry.InjectionHelper;
 import org.terasology.web.io.ActionResult;
+import org.terasology.web.resources.config.ServerMotdResource;
+import org.terasology.web.resources.config.ServerPortResource;
 import org.terasology.web.resources.games.GamesResource;
 import org.terasology.web.resources.modules.AvailableModulesResource;
 
@@ -52,6 +54,8 @@ public final class ResourceManager {
         registerAndPutResource(context, new EngineStateResource());
         registerAndPutResource(context, new GamesResource());
         registerAndPutResource(context, new AvailableModulesResource());
+        registerAndPutResource(context, new ServerMotdResource());
+        registerAndPutResource(context, new ServerPortResource());
         if (gameState instanceof StateIngame) {
             registerAndPutResource(context, new ConsoleResource());
             registerAndPutResource(context, new OnlinePlayersResource());

--- a/src/main/java/org/terasology/web/resources/config/AbstractConfigEntryResource.java
+++ b/src/main/java/org/terasology/web/resources/config/AbstractConfigEntryResource.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.web.resources.config;
+
+import org.terasology.config.Config;
+import org.terasology.network.Client;
+import org.terasology.registry.In;
+import org.terasology.web.ServerAdminsManager;
+import org.terasology.web.resources.ObservableReadableResource;
+import org.terasology.web.resources.ResourceAccessException;
+import org.terasology.web.resources.WritableResource;
+
+public abstract class AbstractConfigEntryResource<T> extends ObservableReadableResource<T> implements WritableResource<T> {
+
+    @In
+    private Config config;
+
+    @Override
+    public T read(Client requestingClient) throws ResourceAccessException {
+        return get(config);
+    }
+
+    @Override
+    public void write(Client requestingClient, T data) throws ResourceAccessException {
+        ServerAdminsManager.checkClientIsServerAdmin(requestingClient.getId());
+        set(config, data);
+        config.save();
+        notifyChangedAll();
+    }
+
+    abstract void set(Config targetConfig, T value);
+    abstract T get(Config sourceConfig);
+}

--- a/src/main/java/org/terasology/web/resources/config/ServerMotdResource.java
+++ b/src/main/java/org/terasology/web/resources/config/ServerMotdResource.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.web.resources.config;
+
+import org.terasology.config.Config;
+
+public class ServerMotdResource extends AbstractConfigEntryResource<String> {
+
+    @Override
+    public String getName() {
+        return "serverMotd";
+    }
+
+    @Override
+    public Class<String> getDataType() {
+        return String.class;
+    }
+
+    @Override
+    void set(Config targetConfig, String value) {
+        targetConfig.getNetwork().setServerMOTD(value);
+    }
+
+    @Override
+    String get(Config sourceConfig) {
+        return sourceConfig.getNetwork().getServerMOTD();
+    }
+}

--- a/src/main/java/org/terasology/web/resources/config/ServerPortResource.java
+++ b/src/main/java/org/terasology/web/resources/config/ServerPortResource.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.web.resources.config;
+
+import org.terasology.config.Config;
+
+public class ServerPortResource extends AbstractConfigEntryResource<Integer> {
+
+    @Override
+    public String getName() {
+        return "serverPort";
+    }
+
+    @Override
+    public Class<Integer> getDataType() {
+        return Integer.class;
+    }
+
+    @Override
+    void set(Config targetConfig, Integer value) {
+        targetConfig.getNetwork().setServerPort(value);
+    }
+
+    @Override
+    Integer get(Config sourceConfig) {
+        return sourceConfig.getNetwork().getServerPort();
+    }
+}


### PR DESCRIPTION
This code adds read and write support for two server configuration entries (the only ones meaningful for a server which I could find, actually): the network listen port and the Message Of The Day (MOTD).

The read access is public (everyone which connects to the server via HTTP or WebSocket can see the value of this settings without authenticating), while the write access requires authentication and requires the client's ID to be in the server admin list (which is, at the moment, stored in a JSON file containing an array of client IDs which has to be manually edited on the server and is read by [this class](https://github.com/MovingBlocks/FacadeServer/blob/2f932ced0876c31d99be3988c955763f81dbedb5/src/main/java/org/terasology/web/ServerAdminsManager.java); it's in the process of being improved for better management, allowing public access until a first client identity is generated, and allowing an admin to add other admins - but anyway this is another story for another pull request).

The [frontend application](https://github.com/gianluca-nitti/FacadeServer-frontend) already supports this feature. In the home tab you can see these infos (if the server is providing them) and from the Settings tab they can be edited (an error message will be shown if you try to save the changes without being authenticated, or if you are authenticated but not in the admin list).