### PR TITLE
Manage administrative permissions

### DIFF
--- a/src/main/java/org/terasology/web/EngineRunner.java
+++ b/src/main/java/org/terasology/web/EngineRunner.java
@@ -48,10 +48,11 @@ public final class EngineRunner {
         populateSubsystems(builder);
         engine = builder.build();
         engine.subscribeToStateChange(() -> {
+            ResourceManager.getInstance().initialize(engine);
             if (engine.getState() instanceof StateMainMenu) {
                 engine.shutdown();
-            } else {
-                ResourceManager.getInstance().initialize(engine);
+            } else if (engine.getState() instanceof StateIngame) {
+                // TODO: add event listeners for onConnected to add the first connected client to the admin list if it's empty
             }
         });
         engine.run(autoStart ? new StateHeadlessSetup() : new StateEngineIdle());

--- a/src/main/java/org/terasology/web/EngineRunner.java
+++ b/src/main/java/org/terasology/web/EngineRunner.java
@@ -15,6 +15,7 @@
  */
 package org.terasology.web;
 
+import org.terasology.engine.ComponentSystemManager;
 import org.terasology.engine.TerasologyEngine;
 import org.terasology.engine.TerasologyEngineBuilder;
 import org.terasology.engine.modes.GameState;
@@ -52,7 +53,7 @@ public final class EngineRunner {
             if (engine.getState() instanceof StateMainMenu) {
                 engine.shutdown();
             } else if (engine.getState() instanceof StateIngame) {
-                // TODO: add event listeners for onConnected to add the first connected client to the admin list if it's empty
+                engine.getState().getContext().get(ComponentSystemManager.class).register(new ServerAdminListUpdaterSystem());
             }
         });
         engine.run(autoStart ? new StateHeadlessSetup() : new StateEngineIdle());

--- a/src/main/java/org/terasology/web/EngineRunner.java
+++ b/src/main/java/org/terasology/web/EngineRunner.java
@@ -30,6 +30,7 @@ import org.terasology.engine.subsystem.headless.HeadlessTimer;
 import org.terasology.engine.subsystem.headless.mode.StateHeadlessSetup;
 import org.terasology.game.Game;
 import org.terasology.web.resources.ResourceManager;
+import org.terasology.web.serverAdminManagement.ServerAdminListUpdaterSystem;
 
 public final class EngineRunner {
 

--- a/src/main/java/org/terasology/web/ServerAdminListUpdaterSystem.java
+++ b/src/main/java/org/terasology/web/ServerAdminListUpdaterSystem.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.web;
+
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.network.events.ConnectedEvent;
+
+public class ServerAdminListUpdaterSystem extends BaseComponentSystem {
+
+    @ReceiveEvent
+    public void onConnected(ConnectedEvent event, EntityRef entityRef) {
+        if (ServerAdminsManager.isAnonymousAdminAccessEnabled()) {
+            ServerAdminsManager.addAdmin(event.getPlayerStore().getId());
+            ServerAdminsManager.saveAdminList();
+        }
+    }
+
+    @Override
+    public void postSave() {
+        ServerAdminsManager.saveAdminList();
+    }
+}

--- a/src/main/java/org/terasology/web/ServerMain.java
+++ b/src/main/java/org/terasology/web/ServerMain.java
@@ -39,6 +39,7 @@ import org.terasology.engine.paths.PathManager;
 import org.terasology.engine.subsystem.common.ConfigurationSubsystem;
 import org.terasology.web.io.ActionResultMessageBodyWriter;
 import org.terasology.web.io.gsonUtils.GsonMessageBodyHandler;
+import org.terasology.web.serverAdminManagement.ServerAdminsManager;
 import org.terasology.web.servlet.AboutServlet;
 import org.terasology.web.servlet.HttpAPIServlet;
 import org.terasology.web.servlet.LogServlet;
@@ -66,7 +67,7 @@ public final class ServerMain {
 
         handleArgs(args);
         setupLogging();
-        ServerAdminsManager.loadAdminList();
+        ServerAdminsManager.getInstance().loadAdminList();
 
         String portEnv = System.getenv("PORT");
         if (portEnv == null) {

--- a/src/main/java/org/terasology/web/io/JsonSession.java
+++ b/src/main/java/org/terasology/web/io/JsonSession.java
@@ -31,6 +31,7 @@ import org.terasology.naming.gson.NameTypeAdapter;
 import org.terasology.naming.gson.VersionTypeAdapter;
 import org.terasology.utilities.gson.UriTypeAdapterFactory;
 import org.terasology.web.EngineRunner;
+import org.terasology.web.ServerAdminsManager;
 import org.terasology.web.authentication.AuthenticationFailedException;
 import org.terasology.web.authentication.AuthenticationHandshakeHandler;
 import org.terasology.web.authentication.AuthenticationHandshakeHandlerImpl;
@@ -203,6 +204,9 @@ public class JsonSession {
         }
         try {
             WritableResource resource = resourceManager.getAs(resourceName, WritableResource.class);
+            if (resource.writeIsAdminRestricted()) {
+                ServerAdminsManager.checkClientIsServerAdmin(client.getId());
+            }
             resource.write(client, GSON.fromJson(data, resource.getDataType()));
             return ActionResult.OK;
         } catch (ResourceAccessException ex) {

--- a/src/main/java/org/terasology/web/io/JsonSession.java
+++ b/src/main/java/org/terasology/web/io/JsonSession.java
@@ -199,13 +199,13 @@ public class JsonSession {
 
     @SuppressWarnings("unchecked")
     public ActionResult writeResource(String resourceName, JsonElement data) {
-        if (!isAuthenticated()) {
-            return new ActionResult(ActionResult.Status.UNAUTHORIZED, "Only authenticated clients can write to resources.");
-        }
         try {
             WritableResource resource = resourceManager.getAs(resourceName, WritableResource.class);
+            if (resource.writeRequiresAuthentication() && !isAuthenticated()) {
+                return new ActionResult(ActionResult.Status.UNAUTHORIZED, "Only authenticated clients can write to this resource.");
+            }
             if (resource.writeIsAdminRestricted()) {
-                ServerAdminsManager.checkClientIsServerAdmin(client.getId());
+                ServerAdminsManager.checkClientHasAdminPermissions(client.getId());
             }
             resource.write(client, GSON.fromJson(data, resource.getDataType()));
             return ActionResult.OK;

--- a/src/main/java/org/terasology/web/io/JsonSession.java
+++ b/src/main/java/org/terasology/web/io/JsonSession.java
@@ -31,7 +31,7 @@ import org.terasology.naming.gson.NameTypeAdapter;
 import org.terasology.naming.gson.VersionTypeAdapter;
 import org.terasology.utilities.gson.UriTypeAdapterFactory;
 import org.terasology.web.EngineRunner;
-import org.terasology.web.ServerAdminsManager;
+import org.terasology.web.serverAdminManagement.ServerAdminsManager;
 import org.terasology.web.authentication.AuthenticationFailedException;
 import org.terasology.web.authentication.AuthenticationHandshakeHandler;
 import org.terasology.web.authentication.AuthenticationHandshakeHandlerImpl;
@@ -205,7 +205,7 @@ public class JsonSession {
                 return new ActionResult(ActionResult.Status.UNAUTHORIZED, "Only authenticated clients can write to this resource.");
             }
             if (resource.writeIsAdminRestricted()) {
-                ServerAdminsManager.checkClientHasAdminPermissions(client.getId());
+                ServerAdminsManager.getInstance().checkClientHasAdminPermissions(client.getId());
             }
             resource.write(client, GSON.fromJson(data, resource.getDataType()));
             return ActionResult.OK;

--- a/src/main/java/org/terasology/web/resources/ConsoleResource.java
+++ b/src/main/java/org/terasology/web/resources/ConsoleResource.java
@@ -50,6 +50,11 @@ public class ConsoleResource extends EventEmittingResource<Message> implements D
     }
 
     @Override
+    public boolean writeRequiresAuthentication() {
+        return true;
+    }
+
+    @Override
     public boolean writeIsAdminRestricted() {
         return false;
     }

--- a/src/main/java/org/terasology/web/resources/ConsoleResource.java
+++ b/src/main/java/org/terasology/web/resources/ConsoleResource.java
@@ -50,6 +50,11 @@ public class ConsoleResource extends EventEmittingResource<Message> implements D
     }
 
     @Override
+    public boolean writeIsAdminRestricted() {
+        return false;
+    }
+
+    @Override
     public void write(Client requestingClient, String data) {
         console.execute(data, requestingClient.getEntity());
     }

--- a/src/main/java/org/terasology/web/resources/EngineStateResource.java
+++ b/src/main/java/org/terasology/web/resources/EngineStateResource.java
@@ -22,7 +22,6 @@ import org.terasology.network.NetworkMode;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameInfo;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameProvider;
-import org.terasology.web.ServerAdminsManager;
 import org.terasology.web.StateEngineIdle;
 import org.terasology.web.io.ActionResult;
 import org.terasology.web.io.JsonSession;
@@ -51,10 +50,14 @@ public class EngineStateResource implements ReadableResource<EngineStateMetadata
     }
 
     @Override
+    public boolean writeIsAdminRestricted() {
+        return true;
+    }
+
+    @Override
     public void write(Client requestingClient, String data) throws ResourceAccessException {
         // if the supplied string is a savegame name, the engine will switch to run this game;
         // if it's empty, it will switch to the idle state.
-        ServerAdminsManager.checkClientIsServerAdmin(requestingClient.getId());
         JsonSession.disconnectAllClients();
         if (data == null || data.length() == 0) {
             gameEngine.changeState(new StateEngineIdle());

--- a/src/main/java/org/terasology/web/resources/EngineStateResource.java
+++ b/src/main/java/org/terasology/web/resources/EngineStateResource.java
@@ -50,6 +50,11 @@ public class EngineStateResource implements ReadableResource<EngineStateMetadata
     }
 
     @Override
+    public boolean writeRequiresAuthentication() {
+        return false;
+    }
+
+    @Override
     public boolean writeIsAdminRestricted() {
         return true;
     }

--- a/src/main/java/org/terasology/web/resources/OnlinePlayerMetadata.java
+++ b/src/main/java/org/terasology/web/resources/OnlinePlayerMetadata.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.web.resources;
+
+import org.terasology.network.Client;
+import org.terasology.rendering.nui.Color;
+
+import java.util.Objects;
+
+public class OnlinePlayerMetadata {
+
+    private String id;
+    private String name;
+    private RgbaColor color;
+
+    public OnlinePlayerMetadata(String id, String name, Color color) {
+        this.id = id;
+        this.name = name;
+        this.color = new RgbaColor(color);
+    }
+
+    public OnlinePlayerMetadata(Client client) {
+        this(client.getId(), client.getName(), client.getColor());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof OnlinePlayerMetadata) {
+            OnlinePlayerMetadata other = (OnlinePlayerMetadata) obj;
+            return id.equals(other.id) && name.equals(other.name) && color.equals(other.color);
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, color);
+    }
+
+    private final class RgbaColor {
+        private int r;
+        private int g;
+        private int b;
+        private int a;
+
+        private RgbaColor(Color source) {
+            r = source.r();
+            g = source.g();
+            b = source.b();
+            a = source.a();
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj instanceof RgbaColor) {
+                RgbaColor other = (RgbaColor) obj;
+                return r == other.r && g == other.g && b == other.b && a == other.a;
+            }
+            return false;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(r, g, b, a);
+        }
+    }
+}

--- a/src/main/java/org/terasology/web/resources/OnlinePlayersResource.java
+++ b/src/main/java/org/terasology/web/resources/OnlinePlayersResource.java
@@ -24,11 +24,12 @@ import org.terasology.network.events.ConnectedEvent;
 import org.terasology.network.events.DisconnectedEvent;
 import org.terasology.registry.In;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 @RegisterSystem
-public class OnlinePlayersResource extends ObservableReadableResource<List<String>> implements DefaultComponentSystem {
+public class OnlinePlayersResource extends ObservableReadableResource<List<OnlinePlayerMetadata>> implements DefaultComponentSystem {
 
     @In
     private NetworkSystem networkSystem;
@@ -52,11 +53,9 @@ public class OnlinePlayersResource extends ObservableReadableResource<List<Strin
     }
 
     @Override
-    public List<String> read(Client requestingClient) {
-        List<String> result = new ArrayList<>();
-        for (Client client: networkSystem.getPlayers()) {
-            result.add(client.getName());
-        }
-        return result;
+    public List<OnlinePlayerMetadata> read(Client requestingClient) {
+        return StreamSupport.stream(networkSystem.getPlayers().spliterator(), true)
+                .map(OnlinePlayerMetadata::new)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/org/terasology/web/resources/ResourceManager.java
+++ b/src/main/java/org/terasology/web/resources/ResourceManager.java
@@ -52,6 +52,7 @@ public final class ResourceManager {
         registerAndPutResource(context, new EngineStateResource());
         registerAndPutResource(context, new GamesResource());
         registerAndPutResource(context, new AvailableModulesResource());
+        registerAndPutResource(context, new ServerAdminsResource());
         if (gameState instanceof StateIngame) {
             registerAndPutResource(context, new ConsoleResource());
             registerAndPutResource(context, new OnlinePlayersResource());

--- a/src/main/java/org/terasology/web/resources/ServerAdminsResource.java
+++ b/src/main/java/org/terasology/web/resources/ServerAdminsResource.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.web.resources;
+
+import org.terasology.network.Client;
+import org.terasology.web.serverAdminManagement.ServerAdminsManager;
+
+import java.util.Set;
+
+public class ServerAdminsResource extends ObservableReadableResource<Set<String>> implements WritableResource<ServerAdminsResourceAction> {
+
+    public ServerAdminsResource() {
+        ServerAdminsManager.getInstance().setOnListChangedCallback(this::notifyChangedAll);
+    }
+
+    @Override
+    public String getName() {
+        return "serverAdmins";
+    }
+
+    @Override
+    public Set<String> read(Client requestingClient) throws ResourceAccessException {
+        return ServerAdminsManager.getInstance().getAdminIds();
+    }
+
+    @Override
+    public Class<ServerAdminsResourceAction> getDataType() {
+        return ServerAdminsResourceAction.class;
+    }
+
+    @Override
+    public boolean writeRequiresAuthentication() {
+        return false;
+    }
+
+    @Override
+    public boolean writeIsAdminRestricted() {
+        return true;
+    }
+
+    @Override
+    public void write(Client requestingClient, ServerAdminsResourceAction data) throws ResourceAccessException {
+        switch(data.getAction()) {
+            case ADD:
+                ServerAdminsManager.getInstance().addAdmin(data.getClientId());
+                break;
+            case REMOVE:
+                ServerAdminsManager.getInstance().removeAdmin(data.getClientId());
+        }
+        ServerAdminsManager.getInstance().saveAdminList();
+    }
+}

--- a/src/main/java/org/terasology/web/resources/ServerAdminsResourceAction.java
+++ b/src/main/java/org/terasology/web/resources/ServerAdminsResourceAction.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.web.resources;
+
+class ServerAdminsResourceAction {
+
+    enum Action {
+        ADD,
+        REMOVE
+    }
+
+    private Action action;
+    private String clientId;
+
+    public Action getAction() {
+        return action;
+    }
+
+    public String getClientId() {
+        return clientId;
+    }
+}

--- a/src/main/java/org/terasology/web/resources/WritableResource.java
+++ b/src/main/java/org/terasology/web/resources/WritableResource.java
@@ -21,6 +21,8 @@ public interface WritableResource<T> extends Resource {
 
     Class<T> getDataType();
 
+    boolean writeRequiresAuthentication();
+
     boolean writeIsAdminRestricted();
 
     void write(Client requestingClient, T data) throws ResourceAccessException;

--- a/src/main/java/org/terasology/web/resources/WritableResource.java
+++ b/src/main/java/org/terasology/web/resources/WritableResource.java
@@ -21,5 +21,7 @@ public interface WritableResource<T> extends Resource {
 
     Class<T> getDataType();
 
+    boolean writeIsAdminRestricted();
+
     void write(Client requestingClient, T data) throws ResourceAccessException;
 }

--- a/src/main/java/org/terasology/web/resources/config/AbstractConfigEntryResource.java
+++ b/src/main/java/org/terasology/web/resources/config/AbstractConfigEntryResource.java
@@ -18,7 +18,6 @@ package org.terasology.web.resources.config;
 import org.terasology.config.Config;
 import org.terasology.network.Client;
 import org.terasology.registry.In;
-import org.terasology.web.ServerAdminsManager;
 import org.terasology.web.resources.ObservableReadableResource;
 import org.terasology.web.resources.ResourceAccessException;
 import org.terasology.web.resources.WritableResource;
@@ -29,13 +28,22 @@ public abstract class AbstractConfigEntryResource<T> extends ObservableReadableR
     private Config config;
 
     @Override
+    public boolean writeRequiresAuthentication() {
+        return false;
+    }
+
+    @Override
+    public boolean writeIsAdminRestricted() {
+        return true;
+    }
+
+    @Override
     public T read(Client requestingClient) throws ResourceAccessException {
         return get(config);
     }
 
     @Override
     public void write(Client requestingClient, T data) throws ResourceAccessException {
-        ServerAdminsManager.checkClientIsServerAdmin(requestingClient.getId());
         set(config, data);
         config.save();
         notifyChangedAll();

--- a/src/main/java/org/terasology/web/resources/games/GamesResource.java
+++ b/src/main/java/org/terasology/web/resources/games/GamesResource.java
@@ -21,7 +21,6 @@ import org.terasology.network.Client;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameInfo;
 import org.terasology.rendering.nui.layers.mainMenu.savedGames.GameProvider;
-import org.terasology.web.ServerAdminsManager;
 import org.terasology.web.resources.ObservableReadableResource;
 import org.terasology.web.resources.ResourceAccessException;
 import org.terasology.web.resources.WritableResource;
@@ -49,8 +48,12 @@ public class GamesResource extends ObservableReadableResource<List<GameInfo>> im
     }
 
     @Override
+    public boolean writeIsAdminRestricted() {
+        return true;
+    }
+
+    @Override
     public void write(Client requestingClient, GameAction data) throws ResourceAccessException {
-        ServerAdminsManager.checkClientIsServerAdmin(requestingClient.getId());
         data.perform(PathManager.getInstance(), moduleManager);
         notifyChangedAll();
     }

--- a/src/main/java/org/terasology/web/resources/games/GamesResource.java
+++ b/src/main/java/org/terasology/web/resources/games/GamesResource.java
@@ -48,6 +48,11 @@ public class GamesResource extends ObservableReadableResource<List<GameInfo>> im
     }
 
     @Override
+    public boolean writeRequiresAuthentication() {
+        return false;
+    }
+
+    @Override
     public boolean writeIsAdminRestricted() {
         return true;
     }

--- a/src/main/java/org/terasology/web/resources/modules/ModuleInstallerResource.java
+++ b/src/main/java/org/terasology/web/resources/modules/ModuleInstallerResource.java
@@ -22,7 +22,6 @@ import org.terasology.naming.Name;
 import org.terasology.network.Client;
 import org.terasology.registry.In;
 import org.terasology.utilities.download.MultiFileTransferProgressListener;
-import org.terasology.web.ServerAdminsManager;
 import org.terasology.web.io.ActionResult;
 import org.terasology.web.resources.ObservableReadableResource;
 import org.terasology.web.resources.ResourceAccessException;
@@ -56,13 +55,22 @@ public class ModuleInstallerResource extends ObservableReadableResource<String> 
     }
 
     @Override
+    public boolean writeRequiresAuthentication() {
+        return false;
+    }
+
+    @Override
+    public boolean writeIsAdminRestricted() {
+        return true;
+    }
+
+    @Override
     public String read(Client requestingClient) throws ResourceAccessException {
         return status;
     }
 
     @Override
     public void write(Client requestingClient, Name[] data) throws ResourceAccessException {
-        ServerAdminsManager.checkClientIsServerAdmin(requestingClient.getId());
         executeCallable(moduleManager.getInstallManager().updateRemoteRegistry());
         Set<Module> allModules;
         try {

--- a/src/main/java/org/terasology/web/serverAdminManagement/ServerAdminListUpdaterSystem.java
+++ b/src/main/java/org/terasology/web/serverAdminManagement/ServerAdminListUpdaterSystem.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.terasology.web;
+package org.terasology.web.serverAdminManagement;
 
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
@@ -24,14 +24,12 @@ public class ServerAdminListUpdaterSystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void onConnected(ConnectedEvent event, EntityRef entityRef) {
-        if (ServerAdminsManager.isAnonymousAdminAccessEnabled()) {
-            ServerAdminsManager.addAdmin(event.getPlayerStore().getId());
-            ServerAdminsManager.saveAdminList();
-        }
+        ServerAdminsManager.getInstance().addFirstAdminIfNecessary(event.getPlayerStore().getId());
+        ServerAdminsManager.getInstance().saveAdminList();
     }
 
     @Override
     public void postSave() {
-        ServerAdminsManager.saveAdminList();
+        ServerAdminsManager.getInstance().saveAdminList();
     }
 }

--- a/src/main/java/org/terasology/web/serverAdminManagement/ServerAdminsManager.java
+++ b/src/main/java/org/terasology/web/serverAdminManagement/ServerAdminsManager.java
@@ -39,6 +39,7 @@ public final class ServerAdminsManager {
 
     private final Path adminListFilePath;
     private Set<String> serverAdminIds;
+    private Runnable onListChanged = () -> { };
 
     ServerAdminsManager(Path adminListFilePath) {
         this.adminListFilePath = adminListFilePath;
@@ -51,6 +52,10 @@ public final class ServerAdminsManager {
 
     private void setServerAdminIds(Set<String> value) {
         serverAdminIds = Collections.synchronizedSet(value);
+    }
+
+    public void setOnListChangedCallback(Runnable callback) {
+        onListChanged = callback;
     }
 
     @SuppressWarnings("unchecked")
@@ -92,10 +97,12 @@ public final class ServerAdminsManager {
 
     public void addAdmin(String id) {
         serverAdminIds.add(id);
+        onListChanged.run();
     }
 
     public void removeAdmin(String id) {
         serverAdminIds.remove(id);
+        onListChanged.run();
     }
 
     public Set<String> getAdminIds() {

--- a/src/test/java/org/terasology/web/io/JsonSessionTest.java
+++ b/src/test/java/org/terasology/web/io/JsonSessionTest.java
@@ -232,6 +232,8 @@ public class JsonSessionTest {
 
         WritableResource<String> writableResource = mock(WritableResource.class);
         when(writableResource.getDataType()).thenReturn(String.class);
+        when(writableResource.writeIsAdminRestricted()).thenReturn(false);
+        when(writableResource.writeRequiresAuthentication()).thenReturn(true);
         ResourceManager resourceManager = mock(ResourceManager.class);
         when(resourceManager.getAs("testResource", WritableResource.class)).thenReturn(writableResource);
 

--- a/src/test/java/org/terasology/web/resources/EngineStateResourceTest.java
+++ b/src/test/java/org/terasology/web/resources/EngineStateResourceTest.java
@@ -22,10 +22,7 @@ import org.terasology.engine.GameEngine;
 import org.terasology.engine.modes.GameState;
 import org.terasology.network.Client;
 import org.terasology.registry.InjectionHelper;
-import org.terasology.web.ServerAdminsManager;
 import org.terasology.web.StateEngineIdle;
-
-import java.util.Arrays;
 
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -43,16 +40,10 @@ public class EngineStateResourceTest {
         engineMock = mock(GameEngine.class);
         GameState state = new StateEngineIdle();
         when(engineMock.getState()).thenReturn(state);
-        ServerAdminsManager.setAdminList(Arrays.asList("serverAdm1", "admin"));
         Context contextMock = mock(Context.class);
         when(contextMock.get(GameEngine.class)).thenReturn(engineMock);
         engineStateResource = new EngineStateResource();
         InjectionHelper.inject(engineStateResource, contextMock);
-    }
-
-    @Test(expected = ResourceAccessException.class)
-    public void testWriteFail() throws ResourceAccessException {
-        engineStateResource.write(mockClient("someUser"), "");
     }
 
     @Test

--- a/src/test/java/org/terasology/web/resources/OnlinePlayersResourceTest.java
+++ b/src/test/java/org/terasology/web/resources/OnlinePlayersResourceTest.java
@@ -24,6 +24,7 @@ import org.terasology.network.NetworkSystem;
 import org.terasology.network.events.ConnectedEvent;
 import org.terasology.network.events.DisconnectedEvent;
 import org.terasology.registry.InjectionHelper;
+import org.terasology.rendering.nui.Color;
 
 import java.util.Arrays;
 import java.util.List;
@@ -37,29 +38,38 @@ import static org.mockito.Mockito.when;
 
 public class OnlinePlayersResourceTest {
 
-    private Client mockClient(String name) {
+    private Client mockClient(String id, String name, Color color) {
         Client result = mock(Client.class);
+        when(result.getId()).thenReturn(id);
         when(result.getName()).thenReturn(name);
+        when(result.getColor()).thenReturn(color);
         return result;
     }
 
     @Test
     public void testRead() {
         NetworkSystem networkSystemMock = mock(NetworkSystem.class);
-        List<Client> clientMocks = Arrays.asList(mockClient("client1"), mockClient("client2"));
+        List<Client> clientMocks = Arrays.asList(
+                mockClient("id1", "name1", new Color(255, 0, 0, 255)),
+                mockClient("id2", "name2", new Color(0, 255, 0, 255))
+        );
         when(networkSystemMock.getPlayers()).thenReturn(clientMocks);
 
         Context context = new ContextImpl();
         context.put(NetworkSystem.class, networkSystemMock);
         OnlinePlayersResource onlinePlayersResource = new OnlinePlayersResource();
         InjectionHelper.inject(onlinePlayersResource, context);
-        assertEquals(Arrays.asList("client1", "client2"), onlinePlayersResource.read(null));
+        List<OnlinePlayerMetadata> expectedResult = Arrays.asList(
+                new OnlinePlayerMetadata("id1", "name1", new Color(255, 0, 0, 255)),
+                new OnlinePlayerMetadata("id2", "name2", new Color(0, 255, 0, 255))
+        );
+        assertEquals(expectedResult, onlinePlayersResource.read(null));
     }
 
     @Test
     @SuppressWarnings("unchecked")
     public void testNotification() {
-        Consumer<ObservableReadableResource<List<String>>> observer = mock(Consumer.class);
+        Consumer<ObservableReadableResource<List<OnlinePlayerMetadata>>> observer = mock(Consumer.class);
 
         Context context = new ContextImpl();
         context.put(NetworkSystem.class, mock(NetworkSystem.class));

--- a/src/test/java/org/terasology/web/resources/games/GamesResourceTest.java
+++ b/src/test/java/org/terasology/web/resources/games/GamesResourceTest.java
@@ -22,10 +22,7 @@ import org.terasology.engine.module.ModuleManager;
 import org.terasology.engine.paths.PathManager;
 import org.terasology.network.Client;
 import org.terasology.registry.InjectionHelper;
-import org.terasology.web.ServerAdminsManager;
 import org.terasology.web.resources.ResourceAccessException;
-
-import java.util.Arrays;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -40,18 +37,12 @@ public class GamesResourceTest {
 
     @Before
     public void setUp() {
-        ServerAdminsManager.setAdminList(Arrays.asList("admin1", "admin2"));
         moduleManagerMock = mock(ModuleManager.class);
         actionMock = mock(GameAction.class);
         Context contextMock = mock(Context.class);
         when(contextMock.get(ModuleManager.class)).thenReturn(moduleManagerMock);
         gamesResource = new GamesResource();
         InjectionHelper.inject(gamesResource, contextMock);
-    }
-
-    @Test(expected = ResourceAccessException.class)
-    public void testWriteNotAllowed() throws ResourceAccessException {
-        gamesResource.write(mockClient("user"), actionMock);
     }
 
     @Test

--- a/src/test/java/org/terasology/web/serverAdminManagement/ServerAdminsManagerTest.java
+++ b/src/test/java/org/terasology/web/serverAdminManagement/ServerAdminsManagerTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.web.serverAdminManagement;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.terasology.web.resources.ResourceAccessException;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static junit.framework.TestCase.assertFalse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ServerAdminsManagerTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    private static <T> void assertSetEquals(Set<T> actualSet, T... expectedItems) {
+        Set<T> expectedSet = new HashSet<>(Arrays.asList(expectedItems));
+        assertEquals(expectedSet, actualSet);
+    }
+
+    private static <T> void assertSetEmpty(Set<T> actualSet) {
+        assertTrue(actualSet.isEmpty());
+    }
+
+    @Test
+    public void testAdminListManipulation() {
+        ServerAdminsManager manager = new ServerAdminsManager(null);
+        assertTrue(manager.isAnonymousAdminAccessEnabled());
+        manager.addAdmin("test");
+        assertSetEquals(manager.getAdminIds(), "test");
+        assertFalse(manager.isAnonymousAdminAccessEnabled());
+        manager.removeAdmin("test");
+        assertSetEmpty(manager.getAdminIds());
+        assertTrue(manager.isAnonymousAdminAccessEnabled());
+    }
+
+    @Test
+    public void testAnonymousOk() throws ResourceAccessException {
+        ServerAdminsManager manager = new ServerAdminsManager(null);
+        manager.checkClientHasAdminPermissions("someone"); // should not throw
+    }
+
+    private ServerAdminsManager setUpWithSingleAdmin(String adminId) {
+        ServerAdminsManager result = new ServerAdminsManager(null);
+        result.addAdmin(adminId);
+        return result;
+    }
+
+    @Test(expected = ResourceAccessException.class)
+    public void testAnonymousFail() throws ResourceAccessException {
+        ServerAdminsManager manager = setUpWithSingleAdmin("testAdmin");
+        manager.checkClientHasAdminPermissions("someUser"); // should throw
+    }
+
+    @Test
+    public void testRegisteredOk() throws ResourceAccessException {
+        ServerAdminsManager manager = setUpWithSingleAdmin("testAdmin");
+        manager.checkClientHasAdminPermissions("testAdmin"); // should not throw
+    }
+
+    @Test
+    public void testAddFirstAdmin() {
+        ServerAdminsManager manager = new ServerAdminsManager(null);
+        assertTrue(manager.isAnonymousAdminAccessEnabled());
+
+        // this is the first one and must be added
+        manager.addFirstAdminIfNecessary("firstAdmin");
+        assertSetEquals(manager.getAdminIds(), "firstAdmin");
+
+        // public access now must be disabled
+        assertFalse(manager.isAnonymousAdminAccessEnabled());
+
+        // this is another user and mustn't be added as an admin, and the anonymous access must remain disabled
+        manager.addFirstAdminIfNecessary("someoneElse");
+        assertSetEquals(manager.getAdminIds(), "firstAdmin");
+        assertFalse(manager.isAnonymousAdminAccessEnabled());
+    }
+
+    @Test
+    public void testSaveLoad() {
+        Path filePath = tempFolder.getRoot().toPath().resolve("admins.json");
+        ServerAdminsManager manager = new ServerAdminsManager(filePath);
+        manager.addAdmin("admin1");
+        manager.addAdmin("admin2");
+        manager.saveAdminList();
+        manager = new ServerAdminsManager(filePath); // reinitialize...
+        manager.loadAdminList(); // ...and reload from same file
+        assertSetEquals(manager.getAdminIds(), "admin1", "admin2");
+    }
+
+}


### PR DESCRIPTION
This pull request contains the code to manage a list of client IDs recognized as server administrators, as described in the first part of the August 13 (week 11) [blog post](https://gianluca-nitti.github.io/GSoC-2017-devlog/).

Short recap:
- Being a server administrators means having write access to the module installer, configuration and savegame list.
- When a new server (i.e. empty data directory) is started for the first time, access to admin-restricted resources is public. The reason for this is that when the server is in the idle state (not running any game) it's not possible to connect using the regular game client, which is what triggers the generation of a client identity; it's only possible to connect anonymously using the web client or API.
- As soon as a regular client connects, that client becomes the only server administrator. the recommended workflow for setting up a server is to start it, access the web interface and create and start a game, then connect using the game client to restrict the administrative access to yourself.
- Using the web interface, an authenticated administrator can add or remove other client IDs from the administrator list by either:
    - pasting the client ID of the new admin, or
    - if a game is running (thus there is a 1:1 correspondence between nicknames and client IDs), picking a name from the list of connected players.
- If an administrator removes everyone from the list including himself so that the admin list becomes empty again, the access to admin-restricted resources becomes public again.

A clarification about the two methods added to `WritableResource`:
- `boolean writeRequiresAuthentication()` must return true if the resource is only writable by a **non-anonymous** player, i.e. it interacts with the in-game entities of the running game and thus a client entity is required to access it. For example to write to `ConsoleResource` (execute a command) you need a client entity; to write to `ModuleInstallerResource` (installing modules) you don't, because you are not manipulating in-game entities.
- `boolean writeIsAdminRestricted()` must return true if writing to the resource is restricted to server administrators; it's possible that a resource is restricted to administrator because it modifies server-wide (and not game-local) files or configuration, but isn't restricted to authenticated clients because it doesn't manipulate in-game objects. In this case, when the admin list is empty (i.e. early server setup phase) this resource can be written to by everyone without authentication.