### PR TITLE
Add system status information to REST API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 
     compile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
 
+    compile group: 'com.github.oshi', name: 'oshi-core', version: '3.4.0'
+
     compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-jetty-servlet', version: jerseyVersion
     compile group: 'org.glassfish.jersey.ext', name: 'jersey-mvc-freemarker', version: jerseyVersion
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 
     compile group: 'javax.servlet', name: 'javax.servlet-api', version: '3.1.0'
 
+    //TODO: update this to newer version if the engine updates its version of JNA
     compile group: 'com.github.oshi', name: 'oshi-core', version: '3.4.0'
 
     compile group: 'org.glassfish.jersey.containers', name: 'jersey-container-jetty-servlet', version: jerseyVersion

--- a/src/main/java/org/terasology/web/ServerMain.java
+++ b/src/main/java/org/terasology/web/ServerMain.java
@@ -94,7 +94,7 @@ public final class ServerMain {
         }
 
         String keystorePassword = System.getenv("KEYSTORE_PASSWORD");
-        if (keystorePassword == null){
+        if (keystorePassword == null) {
             keystorePassword = "ServerKeyPassword";
             logger.warn("Environment variable 'KEYSTORE_PASSWORD' not defined - using default {}", keystorePassword);
         }

--- a/src/main/java/org/terasology/web/resources/ResourceManager.java
+++ b/src/main/java/org/terasology/web/resources/ResourceManager.java
@@ -43,6 +43,7 @@ import org.terasology.web.resources.modules.AvailableModulesResource;
 import org.terasology.web.resources.modules.ModuleInstallerResource;
 import org.terasology.web.resources.onlinePlayers.OnlinePlayersResource;
 import org.terasology.web.resources.serverAdmins.ServerAdminsResource;
+import org.terasology.web.resources.systemStatus.SystemResource;
 import org.terasology.web.resources.worldGenerators.AvailableWorldGeneratorsResource;
 
 import java.util.Arrays;
@@ -92,6 +93,7 @@ public final class ResourceManager implements ResourceObserver {
                         .addSubResource("MOTD", new ServerMotdResource())
                         .build())
                 .addSubResource("serverAdmins", new ServerAdminsResource())
+                .addSubResource("system", new SystemResource())
                 .build();
         rootResource.setObserver(this);
         additionalResourcesToUpdate = new HashMap<>();

--- a/src/main/java/org/terasology/web/resources/ResourceManager.java
+++ b/src/main/java/org/terasology/web/resources/ResourceManager.java
@@ -78,6 +78,7 @@ public final class ResourceManager implements ResourceObserver {
         Context context = gameState.getContext();
 
         Consumer<Resource> resourceInitializer = (resource) -> initializeResource(context, resource);
+        SystemResource systemResource = new SystemResource();
         rootResource = new RouterResource.Builder(resourceInitializer)
                 .addSubResource("onlinePlayers", new OnlinePlayersResource())
                 .addSubResource("console", new ConsoleResource())
@@ -93,8 +94,9 @@ public final class ResourceManager implements ResourceObserver {
                         .addSubResource("MOTD", new ServerMotdResource())
                         .build())
                 .addSubResource("serverAdmins", new ServerAdminsResource())
-                .addSubResource("system", new SystemResource())
+                .addSubResource("system", systemResource)
                 .build();
+        systemResource.startSystemInfoRefreshService();
         rootResource.setObserver(this);
         additionalResourcesToUpdate = new HashMap<>();
         // when /modules/installer changes, also update /modules/available and /worldGenerators

--- a/src/main/java/org/terasology/web/resources/systemStatus/SystemMetadata.java
+++ b/src/main/java/org/terasology/web/resources/systemStatus/SystemMetadata.java
@@ -18,7 +18,8 @@ package org.terasology.web.resources.systemStatus;
 import oshi.SystemInfo;
 import oshi.hardware.HardwareAbstractionLayer;
 
-import java.lang.management.*;
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
 
 
 /**
@@ -30,21 +31,17 @@ public final class SystemMetadata {
     private static SystemMetadata instance;
     private static HardwareAbstractionLayer hardware;
     private static RuntimeMXBean runtimeBean;
-    private static MemoryMXBean memoryBean;
 
     private double cpuUsage;
-    private double memoryUsagePercentage;
     private long memoryUsed;
-    private long memoryTotal;
-    private long memoryAvailable;
+    private long memoryMax;
     private long serverUptime;
     private long jvmMemoryUsed;
-    private long jvmMemoryTotal;
+    private long jvmMemoryMax;
 
     private SystemMetadata() {
         hardware = new SystemInfo().getHardware();
         runtimeBean = ManagementFactory.getRuntimeMXBean();
-        memoryBean = ManagementFactory.getMemoryMXBean();
     }
 
     public static SystemMetadata getInstance() {
@@ -58,37 +55,36 @@ public final class SystemMetadata {
     private void refresh() {
         //Runtime
         cpuUsage = hardware.getProcessor().getSystemCpuLoad() * 100;
-        memoryAvailable = hardware.getMemory().getAvailable();
-        memoryTotal = hardware.getMemory().getTotal();
-        memoryUsed = memoryTotal - memoryAvailable;
-        memoryUsagePercentage = ((double) memoryUsed / memoryTotal) * 100;
+        memoryMax = hardware.getMemory().getTotal();
+        memoryUsed = memoryMax - hardware.getMemory().getAvailable();
         // system uptime in milliseconds
         serverUptime = runtimeBean.getUptime();
         jvmMemoryUsed = Runtime.getRuntime().totalMemory();
-        jvmMemoryTotal = Runtime.getRuntime().maxMemory();
+        jvmMemoryMax = Runtime.getRuntime().maxMemory();
     }
 
     public double getCpuUsage() {
         return cpuUsage;
     }
 
-    public double getMemoryUsagePercentage() {
-        return memoryUsagePercentage;
-    }
-
     public long getMemoryUsed() {
         return memoryUsed;
     }
 
-    public long getMemoryTotal() {
-        return memoryTotal;
-    }
-
-    public long getMemoryAvailable() {
-        return memoryAvailable;
+    public long getMemoryMax() {
+        return memoryMax;
     }
 
     public long getServerUptime() {
         return serverUptime;
     }
+
+    public long getJvmMemoryUsed() {
+        return jvmMemoryUsed;
+    }
+
+    public long getJvmMemoryMax() {
+        return jvmMemoryMax;
+    }
+
 }

--- a/src/main/java/org/terasology/web/resources/systemStatus/SystemMetadata.java
+++ b/src/main/java/org/terasology/web/resources/systemStatus/SystemMetadata.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.web.resources.systemStatus;
+
+import oshi.SystemInfo;
+
+public final class SystemMetadata {
+
+    private double cpuUsage;
+    private double memoryUsagePercentage;
+    private long memoryUsed;
+    private long memoryTotal;
+    private long memoryAvailable;
+    private long systemUptime;
+
+    public static SystemMetadata build() {
+        SystemMetadata systemMetadata = new SystemMetadata();
+        systemMetadata.getStatus();
+        return systemMetadata;
+    }
+
+    private void getStatus() {
+        SystemInfo systemInfo = new SystemInfo();
+        cpuUsage = systemInfo.getHardware().getProcessor().getSystemCpuLoad() * 100;
+        memoryAvailable = systemInfo.getHardware().getMemory().getAvailable();
+        memoryTotal = systemInfo.getHardware().getMemory().getTotal();
+        memoryUsed = memoryTotal - memoryAvailable;
+        memoryUsagePercentage = ((double) memoryUsed / memoryTotal) * 100;
+        // system uptime in seconds
+        systemUptime = systemInfo.getHardware().getProcessor().getSystemUptime();
+    }
+
+    public double getCpuUsage() {
+        return cpuUsage;
+    }
+
+    public double getMemoryUsagePercentage() {
+        return memoryUsagePercentage;
+    }
+
+    public long getMemoryUsed() {
+        return memoryUsed;
+    }
+
+    public long getMemoryTotal() {
+        return memoryTotal;
+    }
+
+    public long getMemoryAvailable() {
+        return memoryAvailable;
+    }
+
+    public long getSystemUptime() {
+        return systemUptime;
+    }
+}

--- a/src/main/java/org/terasology/web/resources/systemStatus/SystemMetadata.java
+++ b/src/main/java/org/terasology/web/resources/systemStatus/SystemMetadata.java
@@ -29,8 +29,8 @@ import java.lang.management.RuntimeMXBean;
 public final class SystemMetadata {
 
     private static SystemMetadata instance;
-    private static HardwareAbstractionLayer hardware;
-    private static RuntimeMXBean runtimeBean;
+    private static HardwareAbstractionLayer hardware = new SystemInfo().getHardware();
+    private static RuntimeMXBean runtimeBean = ManagementFactory.getRuntimeMXBean();
 
     private double cpuUsage;
     private long memoryUsed;
@@ -40,8 +40,6 @@ public final class SystemMetadata {
     private long jvmMemoryMax;
 
     private SystemMetadata() {
-        hardware = new SystemInfo().getHardware();
-        runtimeBean = ManagementFactory.getRuntimeMXBean();
     }
 
     public static SystemMetadata getInstance() {
@@ -53,7 +51,6 @@ public final class SystemMetadata {
     }
 
     private void refresh() {
-        //Runtime
         cpuUsage = hardware.getProcessor().getSystemCpuLoad() * 100;
         memoryMax = hardware.getMemory().getTotal();
         memoryUsed = memoryMax - hardware.getMemory().getAvailable();

--- a/src/main/java/org/terasology/web/resources/systemStatus/SystemResource.java
+++ b/src/main/java/org/terasology/web/resources/systemStatus/SystemResource.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.web.resources.systemStatus;
+
+import org.terasology.web.resources.base.AbstractSimpleResource;
+import org.terasology.web.resources.base.ClientSecurityRequirements;
+import org.terasology.web.resources.base.ResourceAccessException;
+import org.terasology.web.resources.base.ResourceMethod;
+import org.terasology.web.resources.base.ResourcePath;
+
+import static org.terasology.web.resources.base.ResourceMethodFactory.createParameterlessMethod;
+
+public class SystemResource extends AbstractSimpleResource {
+
+    @Override
+    protected ResourceMethod<Void, SystemMetadata> getGetMethod(ResourcePath path) throws ResourceAccessException {
+        return createParameterlessMethod(path, ClientSecurityRequirements.PUBLIC, Void.class,
+                (data, client) -> SystemMetadata.build());
+    }
+
+}

--- a/src/main/java/org/terasology/web/resources/systemStatus/SystemResource.java
+++ b/src/main/java/org/terasology/web/resources/systemStatus/SystemResource.java
@@ -15,15 +15,31 @@
  */
 package org.terasology.web.resources.systemStatus;
 
+import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.web.resources.base.AbstractSimpleResource;
 import org.terasology.web.resources.base.ClientSecurityRequirements;
 import org.terasology.web.resources.base.ResourceAccessException;
 import org.terasology.web.resources.base.ResourceMethod;
 import org.terasology.web.resources.base.ResourcePath;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
 import static org.terasology.web.resources.base.ResourceMethodFactory.createParameterlessMethod;
 
 public class SystemResource extends AbstractSimpleResource {
+
+    private final ScheduledExecutorService refreshSystemInfoService = Executors.newScheduledThreadPool(1);
+
+    public void startSystemInfoRefreshService() {
+        refreshSystemInfoService.scheduleAtFixedRate(this::refreshSystemInfoForClient, 1000, 1000, TimeUnit.MILLISECONDS);
+    }
+
+    @ReceiveEvent
+    public void refreshSystemInfoForClient() {
+        notifyChangedForAllClients();
+    }
 
     @Override
     protected ResourceMethod<Void, SystemMetadata> getGetMethod(ResourcePath path) throws ResourceAccessException {

--- a/src/main/java/org/terasology/web/resources/systemStatus/SystemResource.java
+++ b/src/main/java/org/terasology/web/resources/systemStatus/SystemResource.java
@@ -28,7 +28,7 @@ public class SystemResource extends AbstractSimpleResource {
     @Override
     protected ResourceMethod<Void, SystemMetadata> getGetMethod(ResourcePath path) throws ResourceAccessException {
         return createParameterlessMethod(path, ClientSecurityRequirements.PUBLIC, Void.class,
-                (data, client) -> SystemMetadata.build());
+                (data, client) -> SystemMetadata.getInstance());
     }
 
 }

--- a/src/main/resources/web/swagger.json
+++ b/src/main/resources/web/swagger.json
@@ -172,6 +172,35 @@
             }
           }
         }
+      },
+      "SystemMetadata": {
+        "description": "Contains information on the machine running the server.",
+        "properties": {
+          "cpuUsage": {
+            "type": "number",
+            "description": "The current percentage of CPU usage in the server machine"
+          },
+          "memoryUsed": {
+            "type": "integer",
+            "description": "Current RAM memory in use by the system"
+          },
+          "MemoryMax": {
+            "type": "integer",
+            "description": "Maximum RAM memory available for use by the system"
+          },
+          "serverUptime": {
+            "type": "integer",
+            "description": "Time in milliseconds of how long the server has been running"
+          },
+          "jvmMemoryUsed": {
+            "type": "integer",
+            "description": "Current RAM memory used by the JVM"
+          },
+          "jvmMemoryMax": {
+            "type": "integer",
+            "description": "Maximum available RAM memory for the JVM"
+          }
+        }
       }
     },
     "responses": {
@@ -877,6 +906,28 @@
           },
           "403": {
             "$ref": "#/components/responses/ForbiddenNotAdmin"
+          }
+        }
+      }
+    },
+    "/resources/system": {
+      "parameters": [
+        {
+          "$ref": "#/components/parameters/Session-Token"
+        }
+      ],
+      "get": {
+        "summary": "Gets information on the system running the server.",
+        "responses": {
+          "200": {
+            "description": "System status, including the cpu usage, memory usage, system uptime, and jvm memory usage.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemMetadata"
+                }
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
This PR adds relevant information on the system (CPU usage percentage, memory available/total/used/used percentage, system uptime) to the REST API. To view it, make a GET request to api/resources/system with the web browser or another tool, and notice how the data you get in JSON format describes system information, which you can confirm with task manager or another resource manager.

Oshi, the library used here, uses JNA. Luckily, the main Terasology engine already uses JNA in a few places, so we don't need to add any natives or anything like that. The Terasology engine uses a slightly outdated version of JNA, so we have two options:
1. Use an older version of Oshi (3.4.0 instead of 3.5.0) I don't think this will do any harm. This PR was made with this method, and it already works.
2. Update the version of JNA in the engine. I think this will be more work than it is worth for now.

frontend PR: https://github.com/MovingBlocks/FacadeServer-frontend/pull/3