### PR TITLE
Gradle tweaks to allow standalone/embedded workspace builds/usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,18 @@
+// Dependencies needed for what our Gradle scripts themselves use. It cannot be included via an external Gradle file :-(
+buildscript {
+    repositories {
+        // External libs - jcenter is Bintray and is supposed to be a superset of Maven Central, but do both just in case
+        jcenter()
+        mavenCentral()
+    }
+
+    dependencies {
+        // Artifactory plugin
+        classpath(group: 'org.jfrog.buildinfo', name: 'build-info-extractor-gradle', version: '4.0.0')
+
+    }
+}
+
 plugins {
     id "org.standardout.versioneye" version "1.3.0"
 }
@@ -24,8 +39,14 @@ def jettyVersion = '9.3.8.v20160314'
 def jerseyVersion = '2.22.2'
 
 dependencies {
-    //compile 'org.terasology.engine:engine:1.0.0'
-    compile project(':engine')
+    // Support both standalone workspace (fetch binary engine) and embedding in a Terasology workspace (use local engine source)
+    if (project.name != project(':').name) {
+        compile project(':engine')
+    } else {
+        // For a standalone workspace we need to retrieve the engine from Artifactory instead
+        compile(group: 'org.terasology.engine', name: 'engine', version: '+', changing: true)
+    }
+
     //TODO: add Guava dependency?
 
     compile group: 'org.eclipse.jetty', name: 'jetty-servlet', version: jettyVersion
@@ -96,9 +117,15 @@ task setupServerModules(type: Sync) << {
     into(new File(rootProject.file(localServerDataPath), "modules"))
 }
 
-run.dependsOn rootProject.extractNatives
-run.dependsOn rootProject.moduleClasses
-run.dependsOn setupServerConfig
-run.dependsOn setupServerModules
 run.workingDir = rootDir
 run.args = ["-homedir=terasology-server"]
+run.dependsOn setupServerConfig
+run.dependsOn setupServerModules
+
+// Support both standalone workspace (expect certain things provided) and embedding in a Terasology workspace (use task dependencies)
+if (project.name != project(':').name) {
+    run.dependsOn rootProject.extractNatives
+    run.dependsOn rootProject.moduleClasses
+} else {
+    // For a standalone workspace natives should be provided
+}

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,10 @@ mainClassName = "org.terasology.web.ServerMain"
 
 ext {
     localServerDataPath = 'terasology-server'
-    group = 'org.terasology.web'
 }
+
+// For artifact organizing - version is set in gradle.properties
+group = 'org.terasology.web'
 
 task wrapper(type: Wrapper) {
     gradleVersion = '2.13'


### PR DESCRIPTION
Improves but doesn't fully clean up the current Gradle setup. Tested in the Nanoware fork, Jenkins, and Artifactory.

* http://jenkins.terasology.org/view/Nanoware/job/NanoFacadeServer/6/console
* http://jenkins.terasology.org/view/Nanoware/job/NanoFacadeServer/lastSuccessfulBuild/artifact/build/libs/
* http://artifactory.terasology.org/artifactory/webapp/#/artifacts/browse/tree/General/nanoware-snapshot-local/org/terasology/web/NanoFacadeServer/1.0.0-SNAPSHOT
* http://jenkins.terasology.org/view/Ext/job/FacadeServer (when merged)

Note the location of stuff will change as this is merged to where the regular job will build it instead of the experimental jobs.

Goes with https://github.com/MovingBlocks/Terasology/pull/3371 to fix a pathing issue when the engine is used as a retrieved jar dependency.

Pinging @Inei1 as I can't find via Reviewer dropdown

The regular Jenkins job should be up to date and able to run properly after this is merged.