### PR TITLE
Add Resources for the Blacklist and Whitelist 

### DIFF
--- a/src/main/java/org/terasology/web/resources/ResourceManager.java
+++ b/src/main/java/org/terasology/web/resources/ResourceManager.java
@@ -23,6 +23,7 @@ import org.terasology.engine.TerasologyEngine;
 import org.terasology.engine.modes.GameState;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.systems.ComponentSystem;
+import org.terasology.network.internal.ServerConnectListManager;
 import org.terasology.registry.InjectionHelper;
 import org.terasology.web.client.HeadlessClient;
 import org.terasology.web.io.ActionResult;
@@ -36,6 +37,7 @@ import org.terasology.web.resources.base.ResourcePath;
 import org.terasology.web.resources.base.RouterResource;
 import org.terasology.web.resources.config.ServerMotdResource;
 import org.terasology.web.resources.config.ServerPortResource;
+import org.terasology.web.resources.connectLists.ConnectListResource;
 import org.terasology.web.resources.console.ConsoleResource;
 import org.terasology.web.resources.engineState.EngineStateResource;
 import org.terasology.web.resources.games.GamesResource;
@@ -103,6 +105,8 @@ public final class ResourceManager implements ResourceObserver {
                         .addSubResource("MOTD", new ServerMotdResource())
                         .build())
                 .addSubResource("serverAdmins", new ServerAdminsResource())
+                .addSubResource("blacklist", new ConnectListResource(context.get(ServerConnectListManager.class), ConnectListResource.ConnectListType.BLACKLIST))
+                .addSubResource("whitelist", new ConnectListResource(context.get(ServerConnectListManager.class), ConnectListResource.ConnectListType.WHITELIST))
                 .addSubResource("serverAdminPermissions", new AdminPermissionListResource())
                 .addSubResource("system", systemResource)
                 .build();

--- a/src/main/java/org/terasology/web/resources/connectLists/ConnectListResource.java
+++ b/src/main/java/org/terasology/web/resources/connectLists/ConnectListResource.java
@@ -48,6 +48,7 @@ public class ConnectListResource extends AbstractItemCollectionResource {
                 (data, client) -> typeOfList == ConnectListType.BLACKLIST ? serverConnectListManager.getBlacklist() : serverConnectListManager.getWhitelist());
     }
 
+    // TODO: validate input (check that the input is in the form of a player id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx) where x is an alphanumeric character
     @Override
     protected ResourceMethod<Void, Void> getPostItemMethod(String itemId) throws ResourceAccessException {
         return createVoidParameterlessMethod(ClientSecurityRequirements.requireAdminPermission(PermissionType.CONSOLE_USER_MANAGEMENT), Void.class,
@@ -57,6 +58,7 @@ public class ConnectListResource extends AbstractItemCollectionResource {
                     } else {
                         serverConnectListManager.addToWhitelist(itemId);
                     }
+                    notifyChangedForAllClients();
                 });
     }
 
@@ -69,6 +71,7 @@ public class ConnectListResource extends AbstractItemCollectionResource {
                     } else {
                         serverConnectListManager.removeFromWhitelist(itemId);
                     }
+                    notifyChangedForAllClients();
                 });
     }
 

--- a/src/main/java/org/terasology/web/resources/connectLists/ConnectListResource.java
+++ b/src/main/java/org/terasology/web/resources/connectLists/ConnectListResource.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.web.resources.connectLists;
+
+import org.terasology.network.internal.ServerConnectListManager;
+import org.terasology.web.resources.base.AbstractItemCollectionResource;
+import org.terasology.web.resources.base.ClientSecurityRequirements;
+import org.terasology.web.resources.base.ResourceAccessException;
+import org.terasology.web.resources.base.ResourceMethod;
+import org.terasology.web.serverAdminManagement.PermissionType;
+
+import java.util.Set;
+
+import static org.terasology.web.resources.base.ResourceMethodFactory.createParameterlessMethod;
+import static org.terasology.web.resources.base.ResourceMethodFactory.createVoidParameterlessMethod;
+
+public class ConnectListResource extends AbstractItemCollectionResource {
+
+    public enum ConnectListType {
+        BLACKLIST,
+        WHITELIST
+    }
+
+    private ServerConnectListManager serverConnectListManager;
+    private ConnectListType typeOfList;
+
+    public ConnectListResource(ServerConnectListManager serverConnectListManager, ConnectListType connectListType) {
+        this.serverConnectListManager = serverConnectListManager;
+        this.typeOfList = connectListType;
+    }
+
+    @Override
+    protected ResourceMethod<Void, Set> getGetCollectionMethod() throws ResourceAccessException {
+        return createParameterlessMethod(ClientSecurityRequirements.PUBLIC, Void.class,
+                (data, client) -> typeOfList == ConnectListType.BLACKLIST ? serverConnectListManager.getBlacklist() : serverConnectListManager.getWhitelist());
+    }
+
+    @Override
+    protected ResourceMethod<Void, Void> getPostItemMethod(String itemId) throws ResourceAccessException {
+        return createVoidParameterlessMethod(ClientSecurityRequirements.requireAdminPermission(PermissionType.CONSOLE_USER_MANAGEMENT), Void.class,
+                (data, client) -> {
+                    if (typeOfList == ConnectListType.BLACKLIST) {
+                        serverConnectListManager.addToBlacklist(itemId);
+                    } else {
+                        serverConnectListManager.addToWhitelist(itemId);
+                    }
+                });
+    }
+
+    @Override
+    protected ResourceMethod<Void, Void> getDeleteItemMethod(String itemId) throws ResourceAccessException {
+        return createVoidParameterlessMethod(ClientSecurityRequirements.requireAdminPermission(PermissionType.CONSOLE_USER_MANAGEMENT), Void.class,
+                (data, client) -> {
+                    if (typeOfList == ConnectListType.BLACKLIST) {
+                        serverConnectListManager.removeFromBlacklist(itemId);
+                    } else {
+                        serverConnectListManager.removeFromWhitelist(itemId);
+                    }
+                });
+    }
+
+}


### PR DESCRIPTION
Adds two new resources for the blacklist and whitelist. These features were implemented in the engine by me before GSoC started (see https://github.com/MovingBlocks/Terasology/pull/3332).

To test, use the frontend and look at the new blacklist/whitelist management button on the user management tab. The only thing that seems to work is the GET requests, the other ones display an error when used. I'm not sure why they don't work because I tried to copy the existing serverAdmins resource as closely as I could.