### PR TITLE
add jopenvr.jar to the gradle jar classpath

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ dependencies {
 jar {
     manifest {
         attributes('Main-Class': mainClassName)
-        attributes('Class-Path': configurations.runtime.collect { it.getName() }.join(' '))
+        attributes('Class-Path': "jopenvr.jar " + configurations.runtime.collect { it.getName() }.join(' '))
     }
 }
 


### PR DESCRIPTION
Adds jopenvr.jar to the classpath. This should hopefully be the last thing needed to allow the facade server to run in the omega distribution.