### PR TITLE
Handle more command line arguments

### DIFF
--- a/src/main/java/org/terasology/web/ServerMain.java
+++ b/src/main/java/org/terasology/web/ServerMain.java
@@ -45,6 +45,8 @@ import org.glassfish.jersey.server.mvc.freemarker.FreemarkerMvcFeature;
 import org.glassfish.jersey.servlet.ServletContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.config.Config;
+import org.terasology.config.SystemConfig;
 import org.terasology.engine.LoggingContext;
 import org.terasology.engine.paths.PathManager;
 import org.terasology.engine.subsystem.common.ConfigurationSubsystem;
@@ -65,9 +67,12 @@ public final class ServerMain {
     private static final Logger logger = LoggerFactory.getLogger(ServerMain.class);
 
     private static final String[] ARGS_HELP = {"--help", "-help", "/help", "-h", "/h", "-?", "/?"};
+    private static final String ARG_ENGINE_CURRENT_DIR = "-homedir";
     private static final String ARG_ENGINE_DIR = "-homedir=";
     private static final String ARG_ENGINE_SERVER_PORT = "-serverPort=";
     private static final String ARG_WAIT_MANUAL_START = "-dontStartDefault";
+    private static final String ARG_NO_SAVE_GAMES = "-noSaveGames";
+    private static final String ARG_OVERRIDE_DEFAULT_CONFIG = "-overrideDefaultConfig=";
 
     private static boolean autoStart = true;
 
@@ -128,12 +133,18 @@ public final class ServerMain {
             if (helpArgs.contains(arg)) {
                 printUsage();
                 System.exit(0);
+            } else if (arg.equals(ARG_ENGINE_CURRENT_DIR)) {
+                homePath = Paths.get("");
             } else if (arg.startsWith(ARG_ENGINE_DIR)) {
                 homePath = Paths.get(arg.substring(ARG_ENGINE_DIR.length()));
             } else if (arg.startsWith(ARG_ENGINE_SERVER_PORT)) {
                 System.setProperty(ConfigurationSubsystem.SERVER_PORT_PROPERTY, arg.substring(ARG_ENGINE_SERVER_PORT.length()));
             } else if (arg.equals(ARG_WAIT_MANUAL_START)) {
                 autoStart = false;
+            } else if (arg.equals(ARG_NO_SAVE_GAMES)) {
+                System.setProperty(SystemConfig.SAVED_GAMES_ENABLED_PROPERTY, "false");
+            } else if (arg.startsWith(ARG_OVERRIDE_DEFAULT_CONFIG)) {
+                System.setProperty(Config.PROPERTY_OVERRIDE_DEFAULT_CONFIG, arg.substring(ARG_OVERRIDE_DEFAULT_CONFIG.length()));
             } else {
                 System.err.println("Unrecognized command line argument \"" + arg + "\"");
                 printUsage();
@@ -150,9 +161,12 @@ public final class ServerMain {
 
     private static void printUsage() {
         System.out.println("Available command line options:");
+        System.out.println(ARG_ENGINE_CURRENT_DIR + ": use the current directory as the Terasology engine data directory");
         System.out.println(ARG_ENGINE_DIR + ": use the specified directory as the Terasology engine data directory");
         System.out.println(ARG_ENGINE_SERVER_PORT + ": use the specified port for the Terasology server");
         System.out.println(ARG_WAIT_MANUAL_START + ": do not generate and start a game with the default settings, but wait for manual setup via the web interface");
+        System.out.println(ARG_NO_SAVE_GAMES + ": disable saving game data");
+        System.out.println(ARG_OVERRIDE_DEFAULT_CONFIG + ": override the default config file");
         System.out.println();
         System.out.println("The web server port (default 8080) can be overridden by setting the environment variable HTTP_PORT.");
     }


### PR DESCRIPTION
Solves #26. There are three command line arguments in the PC facade that work with a headless server added by this PR. More testing is needed for the `-overrideDefaultConfig` argument, but the others work perfectly. Most of the new code is duplicated from the PC facade.